### PR TITLE
cloudpathlib 0.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,6 +117,9 @@ about:
   summary: pathlib.Path-style classes for interacting with files in different cloud storage services.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  description: |
+    A Python library with classes that mimic pathlib.Path's interface for URIs from different cloud storage services.
   doc_url: https://cloudpathlib.drivendata.org/
   dev_url: https://github.com/drivendataorg/cloudpathlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,29 @@
 {% set name = "cloudpathlib" %}
-{% set version = "0.13.0" %}
+{% set version = "0.16.0" %}
 
 
 package:
-  name: cloudpathlib
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7135f975b28917348f3ca8feb85f83277c89ac9acf331d1b87d945ecdbe2dffb
+  sha256: cdfcd35d46d529587d744154a0bdf962aca953b725c8784cd2ec478354ea63a3
 
 build:
   number: 0
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - pip
     - python
+    - flit_core >=3.2,<4
   run:
     - python
-    - importlib-metadata  # [py<38]
+    - importlib-metadata    # [py<38]
+    - typing_extensions >4  # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   host:
     - pip
     - python
-    - flit_core >=3.2,<4
+    - flit-core >=3.2,<4
   run:
     - python
     - importlib-metadata    # [py<38]


### PR DESCRIPTION
cloudpathlib 0.16.0

**Destination channel:** defaults

### Links

- [PKG-3485]
- https://github.com/drivendataorg/cloudpathlib/blob/v0.16.0/pyproject.toml

[PKG-3485]: https://anaconda.atlassian.net/browse/PKG-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ